### PR TITLE
Some QoL improvements

### DIFF
--- a/edit/README.md
+++ b/edit/README.md
@@ -98,7 +98,7 @@ The release binaries ship with the bundled assets used by the UI. When a new tag
 - Undo/redo: `Ctrl+Z` / `Ctrl+Shift+Z` or **Edit → Undo / Redo** reverses most actions, including bbox edits, tag changes, Fix Range, linking, and relationship updates. The Edit menu items are enabled and disabled automatically as the undo/redo history changes.
 
 ### 4.3 Fix Range, Linking & Relationships
-- **Fix Range** (formerly "Interpolate") corrects or fills bounding box annotations across a frame range for a selected object. Open it from **Edit → Fix Range** or the sidebar button, then choose a method:
+- **Fix Range** (formerly "Interpolate") corrects or fills bounding box annotations for a selected object. Open it from **Edit → Fix Range** or the sidebar button, choose **Entire range** (uses the object's first and last annotated frames) or **Frame range**, then choose a method:
   - **Linear interpolation** — generates intermediate boxes by linearly blending position, size, and rotation between the two boundary frames (start+1 … end-1). Overwrites any existing annotations in that range.
   - **Re-track forward / Re-track backward** — deletes the existing annotations in the range and re-runs the optical-flow tracker from one boundary frame toward the other, then linearly interpolates the rotation between the two anchors to suppress cumulative drift. Accepts either frame order; enter the range in whichever direction feels natural and the dialog normalises it.
 - **Linking** adds a bounding box for an existing object. Static objects automatically gain boxes in any frames where they were missing; dynamic objects stay unique per frame.

--- a/edit/src/edit/frontend/main_window.py
+++ b/edit/src/edit/frontend/main_window.py
@@ -175,8 +175,6 @@ class MainWindow(QMainWindow):
             self.state,
             self.sidebar_state,
         )
-        self.seek_bar.frame_changed.connect(self.sidebar.on_frame_changed)
-
         main_layout = QHBoxLayout()
         main_layout.addLayout(video_layout, stretch=1)
         main_layout.addWidget(self.sidebar)

--- a/edit/src/edit/frontend/utils/frame_sync.py
+++ b/edit/src/edit/frontend/utils/frame_sync.py
@@ -67,7 +67,6 @@ def _update_overlay_from_model(main_window):
         )
         main_window.sidebar.refresh_active_objects(active_objects, flags)
         main_window.sidebar._refresh_active_frame_tags(current_frame_index)
-        main_window.sidebar.refresh_confidence_issue_list(current_frame_index)
 
     except Exception:
         main_window.overlay.set_rotated_boxes([])

--- a/edit/src/edit/frontend/widgets/interpolation_dialog.py
+++ b/edit/src/edit/frontend/widgets/interpolation_dialog.py
@@ -1,12 +1,14 @@
 from typing import Callable, Dict, List
 
 from PyQt6.QtWidgets import (
+    QButtonGroup,
     QComboBox,
     QDialog,
     QFormLayout,
     QLabel,
     QMessageBox,
     QPushButton,
+    QRadioButton,
     QSpinBox,
     QVBoxLayout,
 )
@@ -78,17 +80,32 @@ class InterpolationDialog(QDialog):
         form.addRow(QLabel("Method:"), self.method_combo)
         form.addRow(self.help_label)
 
+        # Range mode selection
+        self.radio_entire = QRadioButton("Entire range")
+        self.radio_range = QRadioButton("Frame range")
+        self.radio_entire.setChecked(True)
+
+        mode_group = QButtonGroup(self)
+        mode_group.addButton(self.radio_entire)
+        mode_group.addButton(self.radio_range)
+        self.radio_range.toggled.connect(self._toggle_range_inputs)
+
+        form.addRow(QLabel("Range:"), self.radio_entire)
+        form.addRow(QLabel(""), self.radio_range)
+
         # Frame selection
         self.start_frame_spin = QSpinBox()
         self.start_frame_spin.setRange(0, total_frames - 1)
         self.start_frame_spin.setValue(current_frame)
         self.start_frame_spin.valueChanged.connect(self._validate_frames)
+        self.start_frame_spin.setEnabled(False)
         form.addRow(QLabel("Start Frame:"), self.start_frame_spin)
 
         self.end_frame_spin = QSpinBox()
         self.end_frame_spin.setRange(0, total_frames - 1)
         self.end_frame_spin.setValue(min(current_frame + 30, total_frames - 1))
         self.end_frame_spin.valueChanged.connect(self._validate_frames)
+        self.end_frame_spin.setEnabled(False)
         form.addRow(QLabel("End Frame:"), self.end_frame_spin)
 
         # Interpolate and cancel button
@@ -119,9 +136,17 @@ class InterpolationDialog(QDialog):
             )
 
     def _validate_frames(self):
+        if self.radio_entire.isChecked():
+            self.interpolate_btn.setEnabled(True)
+            return
         start = self.start_frame_spin.value()
         end = self.end_frame_spin.value()
         self.interpolate_btn.setEnabled(start != end)
+
+    def _toggle_range_inputs(self, checked: bool):
+        self.start_frame_spin.setEnabled(checked)
+        self.end_frame_spin.setEnabled(checked)
+        self._validate_frames()
 
     def _interpolate(self):
         object_id = self.object_combo.currentData()
@@ -133,24 +158,56 @@ class InterpolationDialog(QDialog):
                 )
                 return
 
-        frame_a = self.start_frame_spin.value()
-        frame_b = self.end_frame_spin.value()
         method = self.method_combo.currentData()
-
-        # Normalize so start_frame <= end_frame for all methods
-        start_frame = min(frame_a, frame_b)
-        end_frame = max(frame_a, frame_b)
-
-        # Verify object exists in both boundary frames
-        for check_frame in (start_frame, end_frame):
-            active_objs = self.parent().annotation_controller.get_active_objects(check_frame)
-            if not any(obj["id"] == object_id for obj in active_objs):
+        if self.radio_entire.isChecked():
+            try:
+                object_frames = self.parent().annotation_controller.frames_for_object(
+                    object_id
+                )
+            except Exception as exc:
                 QMessageBox.warning(
                     self,
                     "Object Not Found",
-                    f"Object {object_id} not found in frame {check_frame}",
+                    str(exc),
                 )
                 return
+            if not object_frames:
+                QMessageBox.warning(
+                    self,
+                    "Object Not Found",
+                    f"Object {object_id} has no annotated frames.",
+                )
+                return
+            start_frame = int(object_frames[0])
+            end_frame = int(object_frames[-1])
+        else:
+            frame_a = self.start_frame_spin.value()
+            frame_b = self.end_frame_spin.value()
+
+            # Normalize so start_frame <= end_frame for all methods
+            start_frame = min(frame_a, frame_b)
+            end_frame = max(frame_a, frame_b)
+
+            # Verify object exists in both boundary frames
+            for check_frame in (start_frame, end_frame):
+                active_objs = self.parent().annotation_controller.get_active_objects(
+                    check_frame
+                )
+                if not any(obj["id"] == object_id for obj in active_objs):
+                    QMessageBox.warning(
+                        self,
+                        "Object Not Found",
+                        f"Object {object_id} not found in frame {check_frame}",
+                    )
+                    return
+
+        if end_frame - start_frame <= 1:
+            QMessageBox.warning(
+                self,
+                "Invalid Range",
+                "The selected range must include at least one intermediate frame.",
+            )
+            return
 
         self.on_interpolate(object_id, start_frame, end_frame, method)
         # For re-track methods the sidebar provides its own messaging;

--- a/edit/src/edit/frontend/widgets/overlay.py
+++ b/edit/src/edit/frontend/widgets/overlay.py
@@ -172,7 +172,10 @@ class Overlay(QWidget):
         self.cascade_button.clicked.connect(self._on_cascade_button_clicked)
 
     def set_frame_size(self, width_vid: int, height_vid: int):
-        self._frame_size = (width_vid, height_vid)
+        size = (int(width_vid), int(height_vid))
+        if self._frame_size == size:
+            return
+        self._frame_size = size
         self.update()
 
     def set_zoom(self, z: float):

--- a/edit/src/edit/frontend/widgets/seek_bar.py
+++ b/edit/src/edit/frontend/widgets/seek_bar.py
@@ -327,9 +327,13 @@ class SeekBar(QWidget):
         Set the current frame on the slider. Optionally emit frame_changed.
         Use this for programmatic frame updates (playback, arrow keys).
         """
-        self.slider.setValue(int(value))
         if emit_signal:
-            self.frame_changed.emit(int(value))
+            self.slider.setValue(int(value))
+            return
+        self.slider.blockSignals(True)
+        self.slider.setValue(int(value))
+        self.slider.blockSignals(False)
+        self.label.setText(f"{int(value)} / {self.slider.maximum()}")
 
     def set_confidence_markers(
         self, warning_frames: list[int] | None, error_frames: list[int] | None
@@ -385,7 +389,6 @@ class SeekBar(QWidget):
         self.frame_input.setVisible(False)
         self.label.setVisible(True)
         self.slider.setValue(value)
-        self.frame_changed.emit(value)
 
     def keyPressEvent(self, event):
         """Cancel frame input on Escape."""

--- a/edit/src/edit/frontend/widgets/sidebar.py
+++ b/edit/src/edit/frontend/widgets/sidebar.py
@@ -75,6 +75,7 @@ from edit.services.exceptions import VideoLoadError
 
 
 class Sidebar(QWidget):
+    _ACTIVE_OBJECT_BASE_TEXT_ROLE = Qt.ItemDataRole.UserRole + 1
 
     open_video = pyqtSignal(str)
     open_config = pyqtSignal(str)
@@ -221,6 +222,18 @@ class Sidebar(QWidget):
         relationships_layout.addWidget(self.relationships_list)
         self._details_content.layout().addRow(relationships_layout)
 
+        # --- Object frame range links ---
+        self._details_frame_links = QLabel("-")
+        self._details_frame_links.setTextFormat(Qt.TextFormat.RichText)
+        self._details_frame_links.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextBrowserInteraction
+        )
+        self._details_frame_links.setOpenExternalLinks(False)
+        self._details_frame_links.linkActivated.connect(
+            self._on_details_frame_link_activated
+        )
+        self._details_content.layout().addRow(QLabel("Frames:"), self._details_frame_links)
+
         main_layout.addWidget(self.details_container)
 
         # --- Active Objects ---
@@ -327,10 +340,87 @@ class Sidebar(QWidget):
             f"Cannot extract object ID from item: {item.text()}"
         )
 
+    def _format_active_object_text(self, obj_type: str, obj_id: str, obj_name: str) -> str:
+        return f"{obj_type} (ID: {obj_id}) - {obj_name}"
+
+    def _format_object_frame_span(self, object_id: str) -> str:
+        try:
+            frames = self.annotation_controller.frames_for_object(object_id)
+        except Exception:
+            return "Frames: n/a"
+
+        if not frames:
+            return "Frames: n/a"
+        if len(frames) == 1:
+            return f"Frames: {frames[0]}"
+        return f"Frames: {frames[0]}–{frames[-1]}"
+
+    def _set_details_frame_links(self, object_id: str) -> None:
+        try:
+            frames = self.annotation_controller.frames_for_object(object_id)
+        except Exception:
+            self._details_frame_links.setText("n/a")
+            return
+
+        if not frames:
+            self._details_frame_links.setText("n/a")
+            return
+
+        first_frame = int(frames[0])
+        last_frame = int(frames[-1])
+        if first_frame == last_frame:
+            self._details_frame_links.setText(
+                f"<a href='frame:{first_frame}'>{first_frame}</a>"
+            )
+            return
+        self._details_frame_links.setText(
+            f"first <a href='frame:{first_frame}'>{first_frame}</a>  |  "
+            f"last <a href='frame:{last_frame}'>{last_frame}</a>"
+        )
+
+    def _on_details_frame_link_activated(self, link: str) -> None:
+        prefix = "frame:"
+        if not link.startswith(prefix):
+            return
+        try:
+            frame_index = int(link[len(prefix) :])
+        except ValueError:
+            return
+        host_window = self.window()
+        if host_window is None:
+            return
+        from edit.frontend.utils.navigation import on_seek
+
+        on_seek(host_window, frame_index)
+
+    def _set_active_object_base_text(self, item: QListWidgetItem, text: str) -> None:
+        item.setData(self._ACTIVE_OBJECT_BASE_TEXT_ROLE, text)
+        item.setText(text)
+
+    def _active_object_base_text(self, item: QListWidgetItem) -> str:
+        value = item.data(self._ACTIVE_OBJECT_BASE_TEXT_ROLE)
+        if value is not None:
+            return str(value)
+        return item.text().splitlines()[0] if item.text() else ""
+
+    def _collapse_active_object_rows(self) -> None:
+        for index in range(self.active_objects.count()):
+            row_item = self.active_objects.item(index)
+            row_item.setText(self._active_object_base_text(row_item))
+
+    def _expand_active_object_row(self, item: QListWidgetItem) -> None:
+        object_id = self._item_object_id(item)
+        base_text = self._active_object_base_text(item)
+        with QSignalBlocker(self.active_objects):
+            self._collapse_active_object_rows()
+            item.setText(f"{base_text}\n{self._format_object_frame_span(object_id)}")
+        self.adjust_list_sizes()
+
     def _on_active_object_selected(self, item):
         # Trigger highlight in the UI
         object_id = self._item_object_id(item)
         self._selected_annotation_object_id = object_id
+        self._expand_active_object_row(item)
         self.highlight_selected_object.emit(object_id)
         self.show_object_editor(object_id, expand=False)
         if QApplication.keyboardModifiers() & Qt.KeyboardModifier.ShiftModifier:
@@ -347,6 +437,7 @@ class Sidebar(QWidget):
                     item.setSelected(True)
                     self.active_objects.setCurrentItem(item)
                     self.active_objects.scrollToItem(item)
+                    self._expand_active_object_row(item)
                     break
 
     def refresh_active_objects(
@@ -362,9 +453,10 @@ class Sidebar(QWidget):
                 obj_id = item.get("id")
                 obj_name = item.get("name") or ""
                 obj_type = item.get("type", "Object")
-                display_text = f"{obj_type} (ID: {obj_id}) - {obj_name}"
-                list_item = QListWidgetItem(display_text)
+                base_text = self._format_active_object_text(obj_type, obj_id, obj_name)
+                list_item = QListWidgetItem(base_text)
                 list_item.setData(Qt.ItemDataRole.UserRole, obj_id)
+                list_item.setData(self._ACTIVE_OBJECT_BASE_TEXT_ROLE, base_text)
 
                 severity = flags.get(obj_id)
                 if severity == "error":
@@ -826,8 +918,12 @@ class Sidebar(QWidget):
                 widget.setMinimumHeight(widget.minimumHeight())
                 widget.setMaximumHeight(16777215)
                 continue
-            row_height = widget.sizeHintForRow(0)
-            content_height = row_height * rows + 6
+            content_height = 6
+            for row_index in range(rows):
+                row_height = widget.sizeHintForRow(row_index)
+                if row_height <= 0:
+                    row_height = widget.fontMetrics().height() + 6
+                content_height += row_height
             widget.setMinimumHeight(max(widget.minimumHeight(), content_height))
             widget.setMaximumHeight(16777215)
 
@@ -1102,6 +1198,7 @@ class Sidebar(QWidget):
 
         # Load and display relationships for this object
         self._refresh_relationships(object_id)
+        self._set_details_frame_links(object_id)
 
         if expand and not self._details_toggle.isChecked():
             self._details_toggle.setChecked(True)
@@ -1175,6 +1272,7 @@ class Sidebar(QWidget):
             self._details_toggle.setChecked(False)
 
         self._details_id_label.setText("-")
+        self._details_frame_links.setText("-")
         self._details_name_edit.blockSignals(True)
         self._details_type_combo.blockSignals(True)
         try:
@@ -1226,9 +1324,10 @@ class Sidebar(QWidget):
                 obj_id = item.get("id")
                 obj_name = item.get("name") or ""
                 obj_type = item.get("type", "Object")
-                display_text = f"{obj_type} (ID: {obj_id}) - {obj_name}"
-                list_item = QListWidgetItem(display_text)
+                base_text = self._format_active_object_text(obj_type, obj_id, obj_name)
+                list_item = QListWidgetItem(base_text)
                 list_item.setData(Qt.ItemDataRole.UserRole, obj_id)
+                list_item.setData(self._ACTIVE_OBJECT_BASE_TEXT_ROLE, base_text)
                 self.active_objects.addItem(list_item)
 
             self.select_active_object_by_id(self._editing_object_id)
@@ -1236,6 +1335,8 @@ class Sidebar(QWidget):
     def _on_active_objects_selection_changed(self):
         if self.active_objects.selectedItems():
             return
+        self._collapse_active_object_rows()
+        self.adjust_list_sizes()
         self.hide_object_editor()
 
     def _open_interpolation_dialog(self):

--- a/edit/src/edit/frontend/widgets/sidebar.py
+++ b/edit/src/edit/frontend/widgets/sidebar.py
@@ -347,13 +347,13 @@ class Sidebar(QWidget):
         try:
             frames = self.annotation_controller.frames_for_object(object_id)
         except Exception:
-            return "Frames: n/a"
+            return "  Frames: n/a"
 
         if not frames:
-            return "Frames: n/a"
+            return "  Frames: n/a"
         if len(frames) == 1:
-            return f"Frames: {frames[0]}"
-        return f"Frames: {frames[0]}–{frames[-1]}"
+            return f"  Frames: {frames[0]}"
+        return f"  Frames: {frames[0]}–{frames[-1]}"
 
     def _set_details_frame_links(self, object_id: str) -> None:
         try:
@@ -374,8 +374,8 @@ class Sidebar(QWidget):
             )
             return
         self._details_frame_links.setText(
-            f"first <a href='frame:{first_frame}'>{first_frame}</a>  |  "
-            f"last <a href='frame:{last_frame}'>{last_frame}</a>"
+            f"<a href='frame:{first_frame}'>{first_frame}</a>  -  "
+            f"<a href='frame:{last_frame}'>{last_frame}</a>"
         )
 
     def _on_details_frame_link_activated(self, link: str) -> None:
@@ -1024,11 +1024,13 @@ class Sidebar(QWidget):
         except Exception:
             active = []
 
-        self.frame_tag_list.clear()
-        for tag, start, end in active:
-            item = QListWidgetItem(f"{tag} [{start}-{end}]")
-            item.setData(Qt.ItemDataRole.UserRole, (tag, int(start), int(end)))
-            self.frame_tag_list.addItem(item)
+        with QSignalBlocker(self.frame_tag_list):
+            self.frame_tag_list.clear()
+            for tag, start, end in active:
+                item = QListWidgetItem(f"{tag} [{start}-{end}]")
+                item.setData(Qt.ItemDataRole.UserRole, (tag, int(start), int(end)))
+                self.frame_tag_list.addItem(item)
+        self.adjust_list_sizes()
         self.refresh_confidence_issue_list(frame_index)
 
     @pyqtSlot(int)
@@ -1037,17 +1039,7 @@ class Sidebar(QWidget):
         Slot called when SeekBar emits frame_changed(int).
         Updates the list to only show tags active at that frame.
         """
-        active = []
-        try:
-            active = self.annotation_controller.active_frame_tags(int(frame_index))
-        except Exception:
-            pass
-
-        self.frame_tag_list.clear()
-        for tag, start, end in active:
-            item = QListWidgetItem(f"{tag} [{start}-{end}]")
-            item.setData(Qt.ItemDataRole.UserRole, (tag, int(start), int(end)))
-            self.frame_tag_list.addItem(item)
+        self._refresh_active_frame_tags(frame_index)
 
     def _add_combo_separator(self, combo: QComboBox, text: str) -> None:
         """Insert a disabled, italic separator item into a combo box."""

--- a/edit/src/edit/services/annotation_service.py
+++ b/edit/src/edit/services/annotation_service.py
@@ -48,6 +48,8 @@ class AnnotationService:
         self._tag_cache_vals: list[str] | None = None
         self._bbox_cache_key: tuple[str, float] | None = None
         self._bbox_cache_vals: Dict[str, List[str]] | None = None
+        self._frame_tag_lookup_cache: dict[int, list[tuple[str, int, int]]] | None = None
+        self._frame_tag_lookup_source: int | None = None
 
     def create_new_object_bbox(
         self, frame_number: int, obj_type: str, coordinates: tuple, annotator: str
@@ -124,13 +126,14 @@ class AnnotationService:
         frame = self.project_state.annotation_config.frames.get(str(frame_number))
         if frame is None:
             return []
-        active_object_keys = frame.objects.keys()
-
-        return [
-            {"type": obj.type, "name": obj.name, "id": key}
-            for key, obj in self.project_state.annotation_config.objects.items()
-            if key in active_object_keys
-        ]
+        global_objects = self.project_state.annotation_config.objects
+        active_objects: list[dict] = []
+        for key in frame.objects.keys():
+            obj = global_objects.get(key)
+            if obj is None:
+                continue
+            active_objects.append({"type": obj.type, "name": obj.name, "id": key})
+        return active_objects
 
     def get_frame_objects(self, frame_limit: int, current_frame: int) -> list[dict]:
         """
@@ -667,6 +670,8 @@ class AnnotationService:
         intervals = openlabel_config.actions[tag].frame_intervals or []
         intervals.append(FrameInterval(frame_start=frame_start, frame_end=frame_end))
         openlabel_config.actions[tag].frame_intervals = intervals
+        self._frame_tag_lookup_cache = None
+        self._frame_tag_lookup_source = None
 
     def get_active_frame_tags(self, frame_index: int):
         """
@@ -683,17 +688,30 @@ class AnnotationService:
         if not openlabel_config or not openlabel_config.actions:
             return []
 
-        active = []
-        for tag_name, action in openlabel_config.actions.items():
-            intervals = getattr(action, "frame_intervals", None) or []
-            for iv in intervals:
-                start = iv.frame_start
-                end = iv.frame_end
-                if start is None or end is None:
-                    continue
-                if int(start) <= frame_index <= int(end):
-                    active.append((tag_name, int(start), int(end)))
-        return active
+        current_actions = openlabel_config.actions
+        current_source = id(current_actions)
+        if (
+            self._frame_tag_lookup_cache is None
+            or self._frame_tag_lookup_source != current_source
+        ):
+            frame_lookup: dict[int, list[tuple[str, int, int]]] = {}
+            for tag_name, action in current_actions.items():
+                intervals = getattr(action, "frame_intervals", None) or []
+                for iv in intervals:
+                    start = iv.frame_start
+                    end = iv.frame_end
+                    if start is None or end is None:
+                        continue
+                    start_idx = int(start)
+                    end_idx = int(end)
+                    for idx in range(start_idx, end_idx + 1):
+                        frame_lookup.setdefault(idx, []).append(
+                            (tag_name, start_idx, end_idx)
+                        )
+            self._frame_tag_lookup_cache = frame_lookup
+            self._frame_tag_lookup_source = current_source
+
+        return list(self._frame_tag_lookup_cache.get(int(frame_index), []))
 
     def bbox_types(self) -> Dict[str, List[str]]:
         """
@@ -757,6 +775,8 @@ class AnnotationService:
             del openlabel_config.actions[tag_name]
             if not openlabel_config.actions:
                 openlabel_config.actions = None
+        self._frame_tag_lookup_cache = None
+        self._frame_tag_lookup_source = None
         return True
 
     def delete_bboxes_by_object(


### PR DESCRIPTION
# Overview

Three improvements:
1. Performance: skipping frame ranges is quicker now
2. Tracking: Re-tracking can now be performed over the entire trajectory of a vehicle (just like spline interpolation) - manually choosing a frame range remains possible
3. Object frame ranges: in the sidebar, now the first and last frame an object occurs are shown. Under "Object details", it is even possible to directly jump to the first and last frame of an object.

# Notes

So far, I have not observed negative impacts on performance or stability from the "performance improvements". 
Re-tracking an object now is very easy, and in many cases performs perfectly. No need anymore to find out the first and last frame of an object, just know the id, "Fix range", and choose to fix the entire trajectory.
To check if tracking is lost somewhere, now simply for every new vehicle directly jump to its last frame using "Object details" frame-jumping.

These three improvements are quite helpful if one goes for a trajectory-tracking annotation approach where one fixes the trajectory of every object individually (which requires a lot of jumps), instead of going frame-by-frame to fix many annotations simultaneously.