### PR TITLE
Bounding box lock-to-center view mode and cascade focus fix

### DIFF
--- a/edit/src/edit/frontend/utils/annotation_ops.py
+++ b/edit/src/edit/frontend/utils/annotation_ops.py
@@ -1,4 +1,6 @@
 # edit/frontend/utils/annotation_ops.py
+from PyQt6.QtCore import QTimer
+
 from edit.frontend.states.annotation_state import AnnotationMode, AnnotationState
 from edit.frontend.states.frontend_state import FrontendState
 from edit.frontend.utils.undo import (
@@ -9,6 +11,8 @@ from edit.frontend.utils.undo import (
     DeleteBBoxCommand,
     DeleteRelationshipCommand,
 )
+
+from edit.frontend.utils.settings_store import get_lock_to_center
 
 from .render import refresh_frame
 from ._annotation_helpers import (
@@ -67,6 +71,14 @@ def wire(main_window, frontend_state: FrontendState):
         main_window.sidebar.highlight_selected_object.connect(
             lambda object_id: highlight_selected_object(main_window, object_id)
         )
+        main_window.sidebar.highlight_selected_object.connect(
+            lambda object_id: _pan_to_center_if_locked(main_window, object_id)
+        )
+
+    if hasattr(main_window.sidebar, "lock_to_center_checkbox"):
+        main_window.sidebar.lock_to_center_checkbox.toggled.connect(
+            lambda checked: _on_lock_to_center_toggled(main_window, checked)
+        )
 
     if hasattr(main_window.sidebar, "zoom_to_selected_object"):
         main_window.sidebar.zoom_to_selected_object.connect(
@@ -88,6 +100,9 @@ def wire(main_window, frontend_state: FrontendState):
     if hasattr(main_window.overlay, "bounding_box_selected"):
         main_window.overlay.bounding_box_selected.connect(
             lambda object_id: highlight_active_obj_list(main_window, object_id)
+        )
+        main_window.overlay.bounding_box_selected.connect(
+            lambda object_id: _pan_to_center_if_locked(main_window, object_id)
         )
 
     if hasattr(main_window.overlay, "deletePressed"):
@@ -371,6 +386,33 @@ def highlight_active_obj_list(main_window, object_id: str):
         sidebar._selected_annotation_object_id = None
         sidebar.active_objects.clearSelection()
         sidebar.hide_object_editor()
+
+
+def _on_lock_to_center_toggled(main_window, checked: bool):
+    """When lock-to-center is enabled, immediately centre the selected bbox."""
+    if not checked:
+        return
+    pan_fn = getattr(main_window, "pan_to_selected_bbox", None)
+    if callable(pan_fn):
+        QTimer.singleShot(0, pan_fn)
+
+
+def _pan_to_center_if_locked(main_window, object_id):
+    """If lock-to-center is active and a bbox was selected, centre it immediately.
+
+    Skipped during frame advances (`_frame_updating` flag set in render.show_frame)
+    because render.show_frame calls pan_to_selected_bbox directly once the overlay
+    state is fully settled.
+    """
+    if not get_lock_to_center():
+        return
+    if getattr(main_window, "_frame_updating", False):
+        return
+    if not object_id:
+        return
+    pan_fn = getattr(main_window, "pan_to_selected_bbox", None)
+    if callable(pan_fn):
+        QTimer.singleShot(0, pan_fn)
 
 
 def on_new_object_bbox(main_window, object_type: str):

--- a/edit/src/edit/frontend/utils/render.py
+++ b/edit/src/edit/frontend/utils/render.py
@@ -1,7 +1,10 @@
 # edit/frontend/utils/render.py
 from __future__ import annotations
 
+from PyQt6.QtCore import QTimer
+
 from edit.frontend.utils.frame_sync import _update_overlay_from_model
+from edit.frontend.utils.settings_store import get_lock_to_center
 
 
 def wire(main_window):
@@ -42,7 +45,15 @@ def show_frame(main_window, pixmap, frame_idx: int | None):
     _clear_selection_for_frame_change(main_window, frame_idx)
     if _prev_selected_id is not None and overlay is not None:
         overlay._preserve_selection_id = _prev_selected_id
-    _update_overlay_from_model(main_window)
+    main_window._frame_updating = True
+    try:
+        _update_overlay_from_model(main_window)
+    finally:
+        main_window._frame_updating = False
+    if get_lock_to_center():
+        pan_fn = getattr(main_window, "pan_to_selected_bbox", None)
+        if callable(pan_fn):
+            QTimer.singleShot(0, pan_fn)
     if hasattr(main_window, "update_issue_info"):
         main_window.update_issue_info()
 

--- a/edit/src/edit/frontend/utils/settings_store.py
+++ b/edit/src/edit/frontend/utils/settings_store.py
@@ -31,6 +31,7 @@ _zoom_rate: float = 1.0
 _bbox_zoom_padding: float = 2.5
 _frame_history_count: int = 50
 _video_buffer_frames: int = 30  # chunk size for VideoReader frame cache
+_lock_to_center: bool = False
 _bookmarks: dict[int, str] = {}  # frame -> note
 _DEFAULT_ONTOLOGY_FILES = ("1.3.1.ttl",)
 
@@ -215,6 +216,17 @@ def set_video_buffer_frames(value: int) -> None:
     if count < 1:
         raise InvalidFrameHistoryCountError("Video buffer must be at least 1 frame.")
     _video_buffer_frames = count
+
+
+def get_lock_to_center() -> bool:
+    """Return whether the selected bbox should be kept centred on frame advance."""
+    return bool(_lock_to_center)
+
+
+def set_lock_to_center(value: bool) -> None:
+    """Enable or disable lock-to-center mode."""
+    global _lock_to_center
+    _lock_to_center = bool(value)
 
 
 def update_tag_options(tag_data: dict[str, dict[str, Iterable[int]]]) -> None:

--- a/edit/src/edit/frontend/utils/zoom.py
+++ b/edit/src/edit/frontend/utils/zoom.py
@@ -192,10 +192,49 @@ def wire(main_window, initial: float | None = None):
         _apply_zoom(new_zoom)
         vw.set_pan(pan_x, pan_y)
 
+    def pan_to_selected_bbox():
+        """Pan so the currently selected bbox is centred in the viewport (zoom unchanged).
+
+        Uses the overlay's own _compute_transform() so the computed pan is guaranteed
+        to match exactly how the overlay renders the selected box — regardless of any
+        difference between the video pixmap size and the overlay's frame_size.
+        """
+        vw = main_window.video_widget
+        overlay = getattr(main_window, "overlay", None)
+        if overlay is None:
+            return
+        bbox = overlay._get_selected_bbox()
+        if bbox is None:
+            return
+
+        # _compute_transform returns (scale, off_x, off_y, base_scale)
+        scale, off_x, off_y, _ = overlay._compute_transform()
+        if scale <= 0:
+            return
+
+        display_w = overlay.width()
+        display_h = overlay.height()
+
+        # Current screen-space position of the bbox centre (before any pan change).
+        current_screen_x = off_x + bbox.center_x * scale
+        current_screen_y = off_y + bbox.center_y * scale
+
+        # Delta needed to shift the bbox centre to the viewport centre.
+        dx = display_w / 2 - current_screen_x
+        dy = display_h / 2 - current_screen_y
+
+        # New pan = current overlay pan + required delta.
+        new_pan_x = overlay._pan_x + dx
+        new_pan_y = overlay._pan_y + dy
+
+        # Use exact pan (no clamping) so edge bboxes reach the true centre.
+        vw.set_pan_exact(new_pan_x, new_pan_y)
+
     main_window.zoom_in = zoom_in
     main_window.zoom_out = zoom_out
     main_window.zoom_fit = zoom_fit
     main_window.zoom_to_bbox = zoom_to_bbox
+    main_window.pan_to_selected_bbox = pan_to_selected_bbox
     main_window.set_default_zoom = lambda value, *, apply=False: _set_default_zoom(
         value, apply=apply
     )

--- a/edit/src/edit/frontend/widgets/cascade_dropdown.py
+++ b/edit/src/edit/frontend/widgets/cascade_dropdown.py
@@ -1,7 +1,7 @@
 # edit/frontend/widgets/cascade_dropdown.py
 from enum import Enum
 
-from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtCore import QEvent, Qt, pyqtSignal
 from PyQt6.QtWidgets import QPushButton, QSizePolicy, QVBoxLayout, QWidget
 
 from edit.frontend.theme.menu_styler import cascade_dropdown_css
@@ -16,6 +16,8 @@ class CascadeDropdown(QWidget):
     """
     A dropdown widget that appears near annotations to provide cascade options.
     """
+
+    closed = pyqtSignal()  # emitted whenever the dropdown is hidden
 
     applySizeToAll = pyqtSignal(object)
     applyRotationToAll = pyqtSignal(object)
@@ -237,6 +239,10 @@ class CascadeDropdown(QWidget):
         """Handle apply last delta to next X frames button click."""
         self.hide()
         self.applyDeltaToFrameRange.emit(self._current_direction)
+
+    def hideEvent(self, event: QEvent) -> None:  # noqa: N802
+        super().hideEvent(event)
+        self.closed.emit()
 
     def _on_cancel(self):
         """Handle cancel button click."""

--- a/edit/src/edit/frontend/widgets/overlay.py
+++ b/edit/src/edit/frontend/widgets/overlay.py
@@ -166,6 +166,7 @@ class Overlay(QWidget):
             self._on_cascade_delta_to_frame_range
         )
         self.cascade_dropdown.cancelled.connect(self._on_cascade_cancel)
+        self.cascade_dropdown.closed.connect(self.setFocus)
 
         # Cascade button
         self.cascade_button = CascadeButton(self)

--- a/edit/src/edit/frontend/widgets/sidebar.py
+++ b/edit/src/edit/frontend/widgets/sidebar.py
@@ -14,6 +14,7 @@ from PyQt6.QtGui import QFont, QIcon, QKeySequence, QShortcut
 from PyQt6.QtWidgets import (
     QAbstractItemView,
     QApplication,
+    QCheckBox,
     QComboBox,
     QDialog,
     QDialogButtonBox,
@@ -57,7 +58,11 @@ from edit.frontend.utils.project_io import (
     ProjectDirectoryContents,
     scan_project_directory,
 )
-from edit.frontend.utils.settings_store import get_ontology_path
+from edit.frontend.utils.settings_store import (
+    get_lock_to_center,
+    get_ontology_path,
+    set_lock_to_center,
+)
 from edit.frontend.utils.sidebar_confidence_items import (
     SidebarConfidenceIssueItemDelegate,
 )
@@ -322,6 +327,15 @@ class Sidebar(QWidget):
         self.refresh_confidence_issue_list()
 
         # Finalize Scroll Area
+        # --- View options ---
+        self.lock_to_center_checkbox = QCheckBox("Lock selected to center")
+        self.lock_to_center_checkbox.setToolTip(
+            "Keep the selected bounding box centred in the view when stepping frames"
+        )
+        self.lock_to_center_checkbox.setChecked(get_lock_to_center())
+        self.lock_to_center_checkbox.toggled.connect(set_lock_to_center)
+        main_layout.addWidget(self.lock_to_center_checkbox)
+
         main_layout.addStretch()  # Pushes content to top
         self.scroll_area.setWidget(self.content_widget)
         outer_layout.addWidget(self.scroll_area)

--- a/edit/src/edit/frontend/widgets/video_display.py
+++ b/edit/src/edit/frontend/widgets/video_display.py
@@ -315,6 +315,14 @@ class VideoDisplay(QLabel):
         self.update()
         self.pan_changed.emit(self._pan.x(), self._pan.y())
 
+    def set_pan_exact(self, pan_x: float, pan_y: float) -> None:
+        """Set pan without clamping — used by lock-to-center so edge bboxes
+        can be precisely centred even when the required offset exceeds the
+        normal canvas padding limit."""
+        self._pan = QPointF(pan_x, pan_y)
+        self.update()
+        self.pan_changed.emit(self._pan.x(), self._pan.y())
+
     def show_frame(self, pixmap: QPixmap) -> None:
         """Show a new frame in the video display."""
         if pixmap and not pixmap.isNull():


### PR DESCRIPTION
## Summary

Adds a **Lock selected to center** checkbox to the right panel that keeps the selected bounding box centred in the viewport when stepping through frames. Also fixes a keyboard focus loss that occurred after using the cascade dropdown.

## Lock-to-center view mode

A new checkbox "Lock selected to center" appears at the bottom of the right panel.

When enabled:
- The viewport pans to keep the selected bbox centred on every frame step (spacebar / arrow key)
- Centering triggers immediately when selecting a bbox by clicking on it in the video, in the object list, or when the checkbox is turned on with a bbox already selected
- Edge bboxes are centred precisely — pan clamping is bypassed for this mode only

## Cascade dropdown: keyboard focus restored

After clicking a cascade action (Forwards/Backwards + Apply …), keyboard focus was captured by the button and not returned to the overlay. Arrow keys and spacebar had no effect until the user clicked the overlay with the mouse again.

The overlay now reclaims focus automatically as soon as the cascade dropdown closes, whether an action was applied or cancelled.